### PR TITLE
Python: fixed '/user/{id}' end point server error

### DIFF
--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,0 +1,2 @@
+# ignore python virtual environment files
+env/

--- a/python/app.py
+++ b/python/app.py
@@ -29,7 +29,7 @@ def get_users():
 
 @app.route("/user/<int:user_id>", methods=['GET'])
 def get_user(user_id):
-    resp = "User " + user_id
+    resp = "User {}".format(user_id)
     return jsonify(resp)
 
 @app.route("/user/add", methods=['POST'])


### PR DESCRIPTION
- fixed sample user endpoint that was throwing error due to string + int concatenation
- added .gitignore with 'env' directory entry to avoid users checking in virtual environment 
  working files