### PR TITLE
implement book creation

### DIFF
--- a/ruby/booksAPI-jfb.rb
+++ b/ruby/booksAPI-jfb.rb
@@ -50,6 +50,19 @@ class Booklistapp < Sinatra::Base
 
   # CREATE a book
   post '/books/add' do
+    req_in = JSON.parse(request.body.read)
+    if req_in and req_in['author_first_name'] and req_in['author_last_name'] and req_in['title'] and req_in['page_number']
+      ids = []
+      books_db.each { |row|
+        ids << row['id']
+      }
+      next_id = ids.max + 1
+      req_in['id'] = next_id
+      books_db << req_in
+      req_in.to_s
+    else
+      "Incomplete record received"
+    end # if req_in ...
   end
 
   # UPDATE a book


### PR DESCRIPTION
`POST /books/add` expects a single JSON entry (not an array) containing the following keys:

- `title`
- `author_first_name`
- `author_last_name`
- `page_number`

If an `id` key is included, it is overwritten with a value one higher than the current highest `id` value. (The race condition this creates is of course outside of the scope of this exercise. 😜) If keys other than the required keys or `id` are specified, they will be kept.

Following a successful HTTP post, the new record is added to the in-memory database. The `books.json` input file is not modified, but added entries will be kept in memory for the lifetime of the server process.

Creating a new person is left as an exercise to the student.